### PR TITLE
Declare GPLv2 license and maintainer email

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,13 +7,13 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="gslivm@todo.todo">gslivm</maintainer>
+  <maintainer email="maintainer@example.com">gslivm</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>GPLv2</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->

--- a/package_livox.xml
+++ b/package_livox.xml
@@ -7,13 +7,13 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="gslivm@todo.todo">gslivm</maintainer>
+  <maintainer email="maintainer@example.com">gslivm</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>GPLv2</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>eigen_conversions</build_depend>
@@ -37,7 +37,7 @@
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>tf</build_export_depend>
   <build_depend>livox_ros_driver2</build_depend>
-  <exec_depend>livox_ros_driver2</run_depend>
+  <exec_depend>livox_ros_driver2</exec_depend>
   <exec_depend>eigen_conversions</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>


### PR DESCRIPTION
## Summary
- Declare GPLv2 license and set maintainer email for main package manifest
- Apply same metadata updates to Livox manifest and correct livox_ros_driver2 dependency

## Testing
- `xmllint --noout package.xml package_livox.xml` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be40635cd08323a78c8e0f7f8a17ca