### PR TITLE
Mark eskfEstimator getters const

### DIFF
--- a/include/liw/eskfEstimator.h
+++ b/include/liw/eskfEstimator.h
@@ -84,23 +84,23 @@ class eskfEstimator {
 
   void setCovariance(const Eigen::Matrix<double, 17, 17>& covariance_);
 
-  Eigen::Matrix<double, 17, 17> getCovariance();
+  const Eigen::Matrix<double, 17, 17>& getCovariance() const;
 
-  Eigen::Vector3d getTranslation();
+  const Eigen::Vector3d& getTranslation() const;
 
-  Eigen::Quaterniond getRotation();
+  const Eigen::Quaterniond& getRotation() const;
 
-  Eigen::Vector3d getVelocity();
+  const Eigen::Vector3d& getVelocity() const;
 
-  Eigen::Vector3d getBa();
+  const Eigen::Vector3d& getBa() const;
 
-  Eigen::Vector3d getBg();
+  const Eigen::Vector3d& getBg() const;
 
-  Eigen::Vector3d getGravity();
+  const Eigen::Vector3d& getGravity() const;
 
-  Eigen::Vector3d getLastAcc();
+  const Eigen::Vector3d& getLastAcc() const;
 
-  Eigen::Vector3d getLastGyr();
+  const Eigen::Vector3d& getLastGyr() const;
 
   void predict(double dt_, const Eigen::Vector3d& acc_1_, const Eigen::Vector3d& gyr_1_);
 

--- a/src/liw/eskfEstimator.cpp
+++ b/src/liw/eskfEstimator.cpp
@@ -144,35 +144,35 @@ void eskfEstimator::setGravity(const Eigen::Vector3d& g_) {
   g = g_;
 }
 
-Eigen::Vector3d eskfEstimator::getTranslation() {
+const Eigen::Vector3d& eskfEstimator::getTranslation() const {
   return p;
 }
 
-Eigen::Quaterniond eskfEstimator::getRotation() {
+const Eigen::Quaterniond& eskfEstimator::getRotation() const {
   return q;
 }
 
-Eigen::Vector3d eskfEstimator::getVelocity() {
+const Eigen::Vector3d& eskfEstimator::getVelocity() const {
   return v;
 }
 
-Eigen::Vector3d eskfEstimator::getBa() {
+const Eigen::Vector3d& eskfEstimator::getBa() const {
   return ba;
 }
 
-Eigen::Vector3d eskfEstimator::getBg() {
+const Eigen::Vector3d& eskfEstimator::getBg() const {
   return bg;
 }
 
-Eigen::Vector3d eskfEstimator::getGravity() {
+const Eigen::Vector3d& eskfEstimator::getGravity() const {
   return g;
 }
 
-Eigen::Vector3d eskfEstimator::getLastAcc() {
+const Eigen::Vector3d& eskfEstimator::getLastAcc() const {
   return acc_0;
 }
 
-Eigen::Vector3d eskfEstimator::getLastGyr() {
+const Eigen::Vector3d& eskfEstimator::getLastGyr() const {
   return gyr_0;
 }
 
@@ -180,7 +180,7 @@ void eskfEstimator::setCovariance(const Eigen::Matrix<double, 17, 17>& covarianc
   covariance = covariance_;
 }
 
-Eigen::Matrix<double, 17, 17> eskfEstimator::getCovariance() {
+const Eigen::Matrix<double, 17, 17>& eskfEstimator::getCovariance() const {
   return covariance;
 }
 


### PR DESCRIPTION
## Summary
- make `eskfEstimator` getter methods const and return const references to internal state

## Testing
- `cmake .. -DBUILD_GS=OFF` *(fails: Could not find package configuration file provided by "catkin")*

------
https://chatgpt.com/codex/tasks/task_e_68be406b8af8832389460acbeccd80e0