### PR TITLE
Add ESKF estimator unit tests

### DIFF
--- a/include/liw/eskfEstimator.h
+++ b/include/liw/eskfEstimator.h
@@ -10,11 +10,8 @@
 // eigen
 #include <Eigen/Core>
 
-// ceres
-#include <ceres/ceres.h>
-
-// utility
-#include "liw/utility.h"
+// helpers
+#include "liw/eskf_utils.h"
 
 class eskfEstimator {
  private:

--- a/include/liw/eskf_utils.h
+++ b/include/liw/eskf_utils.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <cmath>
+#include <iostream>
+
+// Basic constants used by the estimator
+constexpr double THETA_THRESHOLD = 0.0001;
+constexpr int MIN_INI_COUNT = 20;
+constexpr double MIN_INI_TIME = 0.2;
+constexpr double MAX_GYR_VAR = 0.5;
+constexpr double MAX_ACC_VAR = 0.6;
+
+// Global flags/values expected by the estimator implementation
+extern bool initial_flag;
+extern double G_norm;
+
+// Simple stand-ins for ROS and glog macros used in the original project
+#ifndef ROS_INFO
+#define ROS_INFO(... ) do { (void)0; } while(0)
+#endif
+#ifndef LOG
+#define LOG(level) std::cerr
+#endif
+
+struct numType {
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar, 3, 3> normalizeR(
+      const Eigen::MatrixBase<Derived>& R_in) {
+    typedef typename Derived::Scalar Scalar_t;
+    Eigen::Quaternion<Scalar_t> q(R_in);
+    q.normalize();
+    return q.toRotationMatrix();
+  }
+
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar, 3, 3> skewSymmetric(
+      const Eigen::MatrixBase<Derived>& mat) {
+    typedef typename Derived::Scalar Scalar_t;
+    Eigen::Matrix<Scalar_t, 3, 3> mat_skew;
+    mat_skew << Scalar_t(0), -mat(2), mat(1),
+        mat(2), Scalar_t(0), -mat(0),
+        -mat(1), mat(0), Scalar_t(0);
+    return mat_skew;
+  }
+
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar, 3, 2> derivativeS2(
+      const Eigen::MatrixBase<Derived>& g_in) {
+    typedef typename Derived::Scalar Scalar_t;
+    Eigen::Matrix<Scalar_t, 3, 2> B_x;
+    Eigen::Matrix<Scalar_t, 3, 1> g = g_in;
+    g.normalize();
+    B_x(0, 0) = Scalar_t(1.0) - g(0) * g(0) / (Scalar_t(1.0) + g(2));
+    B_x(0, 1) = -g(0) * g(1) / (Scalar_t(1.0) + g(2));
+    B_x(1, 0) = B_x(0, 1);
+    B_x(1, 1) = Scalar_t(1.0) - g(1) * g(1) / (Scalar_t(1.0) + g(2));
+    B_x(2, 0) = -g(0);
+    B_x(2, 1) = -g(1);
+    return B_x;
+  }
+
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar, 3, 1> rotationToSo3(
+      const Eigen::MatrixBase<Derived>& R_in) {
+    typedef typename Derived::Scalar Scalar_t;
+    Eigen::Matrix<Scalar_t, 3, 3> R = normalizeR(R_in);
+    Scalar_t theta = acos((R(0,0)+R(1,1)+R(2,2)-Scalar_t(1.0))/Scalar_t(2));
+    if (theta < Scalar_t(THETA_THRESHOLD)) {
+      return Eigen::Matrix<Scalar_t,3,1>(R(2,1)-R(1,2), R(0,2)-R(2,0), R(1,0)-R(0,1)) / Scalar_t(2.0);
+    } else {
+      return theta * Eigen::Matrix<Scalar_t,3,1>(R(2,1)-R(1,2), R(0,2)-R(2,0), R(1,0)-R(0,1)) /
+             (Scalar_t(2.0)*sin(theta));
+    }
+  }
+
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar, 3, 3> so3ToRotation(
+      const Eigen::MatrixBase<Derived>& so3_in) {
+    typedef typename Derived::Scalar Scalar_t;
+    Scalar_t theta = so3_in.norm();
+    if (theta < Scalar_t(THETA_THRESHOLD)) {
+      Eigen::Matrix<Scalar_t,3,3> u_x = skewSymmetric(so3_in);
+      return Eigen::Matrix<Scalar_t,3,3>::Identity() + u_x + Scalar_t(0.5) * u_x * u_x;
+    } else {
+      Eigen::Matrix<Scalar_t,3,3> u_x = skewSymmetric(so3_in.normalized());
+      return Eigen::Matrix<Scalar_t,3,3>::Identity() + sin(theta) * u_x +
+             (Scalar_t(1) - cos(theta)) * u_x * u_x;
+    }
+  }
+
+  template <typename Derived>
+  static Eigen::Quaternion<typename Derived::Scalar> so3ToQuat(
+      const Eigen::MatrixBase<Derived>& so3_in) {
+    typedef typename Derived::Scalar Scalar_t;
+    Scalar_t theta = so3_in.norm();
+    if (theta < Scalar_t(THETA_THRESHOLD)) {
+      Eigen::Matrix<Scalar_t,3,1> half_so3 = so3_in / Scalar_t(2.0);
+      Eigen::Quaternion<Scalar_t> q(Scalar_t(1.0), half_so3.x(), half_so3.y(), half_so3.z());
+      q.normalize();
+      return q;
+    } else {
+      Eigen::Matrix<Scalar_t,3,1> u = so3_in.normalized();
+      Eigen::Quaternion<Scalar_t> q(
+          cos(Scalar_t(0.5)*theta),
+          u.x()*sin(Scalar_t(0.5)*theta),
+          u.y()*sin(Scalar_t(0.5)*theta),
+          u.z()*sin(Scalar_t(0.5)*theta));
+      q.normalize();
+      return q;
+    }
+  }
+
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar,3,1> quatToSo3(
+      const Eigen::QuaternionBase<Derived>& q_in) {
+    return rotationToSo3(q_in.toRotationMatrix());
+  }
+
+  template <typename Derived>
+  static Eigen::Matrix<typename Derived::Scalar,3,3> invJrightSo3(
+      const Eigen::MatrixBase<Derived>& so3_in) {
+    typedef typename Derived::Scalar Scalar_t;
+    Scalar_t theta = so3_in.norm();
+    if (theta < Scalar_t(THETA_THRESHOLD)) {
+      return cos(theta/Scalar_t(2)) * Eigen::Matrix<Scalar_t,3,3>::Identity() +
+             Scalar_t(0.125) * so3_in * so3_in.transpose() +
+             Scalar_t(0.5) * skewSymmetric(so3_in);
+    } else {
+      Eigen::Matrix<Scalar_t,3,1> u = so3_in.normalized();
+      return Scalar_t(0.5)*theta/tan(theta/Scalar_t(2)) * Eigen::Matrix<Scalar_t,3,3>::Identity() +
+             (Scalar_t(1) - Scalar_t(0.5)*theta/tan(theta/Scalar_t(2))) * u * u.transpose() +
+             Scalar_t(0.5) * skewSymmetric(so3_in);
+    }
+  }
+};
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.10)
+project(eskf_tests)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+find_package(Eigen3 REQUIRED)
+
+include_directories(${EIGEN3_INCLUDE_DIR} ../include)
+
+add_library(eskf STATIC ../src/liw/eskfEstimator.cpp)
+target_include_directories(eskf PRIVATE ../include)
+
+add_executable(test_eskf_estimator test_eskf_estimator.cpp)
+target_link_libraries(test_eskf_estimator eskf gtest_main)
+
+enable_testing()
+add_test(NAME eskf_estimator_test COMMAND test_eskf_estimator)

--- a/test/test_eskf_estimator.cpp
+++ b/test/test_eskf_estimator.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include "liw/eskfEstimator.h"
+
+// Define global variables expected by eskf_utils
+bool initial_flag = false;
+double G_norm = 9.81;
+
+// Helper to generate initialization IMU data
+static std::vector<std::pair<double, std::pair<Eigen::Vector3d, Eigen::Vector3d>>>
+createInitImu(double dt, int n) {
+  std::vector<std::pair<double, std::pair<Eigen::Vector3d, Eigen::Vector3d>>> meas;
+  for (int i = 0; i < n; ++i) {
+    double t = i * dt;
+    Eigen::Vector3d gyr = Eigen::Vector3d::Zero();
+    Eigen::Vector3d acc(0.0, 0.0, 9.81);
+    meas.push_back({t, {gyr, acc}});
+  }
+  return meas;
+}
+
+TEST(ESKFEstimator, GravityInitialization) {
+  eskfEstimator eskf;
+  eskf.setAccCov(1e-2);
+  eskf.setGyrCov(1e-4);
+  eskf.setBiasAccCov(1e-6);
+  eskf.setBiasGyrCov(1e-6);
+
+  auto meas = createInitImu(0.01, 25);
+  eskf.tryInit(meas);
+
+  EXPECT_TRUE(initial_flag);
+  Eigen::Vector3d g = eskf.getGravity();
+  EXPECT_NEAR(g.x(), 0.0, 1e-3);
+  EXPECT_NEAR(g.y(), 0.0, 1e-3);
+  EXPECT_NEAR(g.z(), 9.81, 1e-3);
+  EXPECT_NEAR(eskf.getBg().norm(), 0.0, 1e-5);
+}
+
+TEST(ESKFEstimator, PropagationAndCovariance) {
+  eskfEstimator eskf;
+  eskf.setAccCov(1e-2);
+  eskf.setGyrCov(1e-4);
+  eskf.setBiasAccCov(1e-6);
+  eskf.setBiasGyrCov(1e-6);
+
+  auto meas = createInitImu(0.01, 25);
+  eskf.tryInit(meas);
+
+  double dt = 0.1;
+  for (int i = 0; i < 10; ++i) {
+    Eigen::Vector3d acc(1.0, 0.0, 9.81);
+    Eigen::Vector3d gyr = Eigen::Vector3d::Zero();
+    eskf.predict(dt, acc, gyr);
+  }
+
+  Eigen::Vector3d p = eskf.getTranslation();
+  Eigen::Vector3d v = eskf.getVelocity();
+  EXPECT_NEAR(p.x(), 0.5, 1e-2);
+  EXPECT_NEAR(p.y(), 0.0, 1e-3);
+  EXPECT_NEAR(p.z(), 0.0, 1e-2);
+  EXPECT_NEAR(v.x(), 1.0, 1e-3);
+  EXPECT_NEAR(v.y(), 0.0, 1e-3);
+  EXPECT_NEAR(v.z(), 0.0, 1e-3);
+
+  Eigen::Matrix<double,17,17> cov = eskf.getCovariance();
+  EXPECT_GT((cov - Eigen::Matrix<double,17,17>::Identity()).norm(), 1e-6);
+  EXPECT_GT(cov(0,0), 1.0);
+}
+
+TEST(ESKFEstimator, BiasSetterGetterAndReset) {
+  eskfEstimator eskf;
+  eskf.setAccCov(1e-2);
+  eskf.setGyrCov(1e-4);
+  eskf.setBiasAccCov(1e-6);
+  eskf.setBiasGyrCov(1e-6);
+
+  auto meas = createInitImu(0.01, 25);
+  eskf.tryInit(meas);
+
+  Eigen::Vector3d ba(0.01, -0.02, 0.03);
+  Eigen::Vector3d bg(-0.001, 0.002, -0.003);
+  eskf.setBa(ba);
+  eskf.setBg(bg);
+  EXPECT_TRUE(eskf.getBa().isApprox(ba));
+  EXPECT_TRUE(eskf.getBg().isApprox(bg));
+
+  // propagate one step with biased acceleration
+  Eigen::Vector3d acc(1.0, 0.0, 9.81);
+  Eigen::Vector3d gyr = Eigen::Vector3d::Zero();
+  eskf.predict(0.1, acc, gyr);
+
+  eskf.calculateLxly();
+  eskf.observePose(Eigen::Vector3d::Zero(), Eigen::Quaterniond::Identity());
+  EXPECT_NEAR(eskf.getTranslation().norm(), 0.0, 1e-3);
+  EXPECT_NEAR(eskf.getVelocity().norm(), 0.0, 1e-3);
+  EXPECT_TRUE(eskf.getRotation().isApprox(Eigen::Quaterniond::Identity(), 1e-3));
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
## Summary
- add gtest-based unit tests for eskfEstimator
- factor out minimal eskf utilities to decouple from ROS dependencies
- provide CMake harness for running estimator tests

## Testing
- `cmake -S test -B build/test` *(fails: HTTP 403 when downloading googletest)*

------
https://chatgpt.com/codex/tasks/task_e_68be41fc39ac83238ef793ffa5ca1989