### PR TITLE
Add multi-sensor setup guide and example configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ D. Variance centerd Framework is developed to calculate the initialization param
 
 E. Easy-to-use. ROS-related code is provided. Any bags contains image, LiDAR points, IMU can be processed.
 
+For wiring, calibration, and configuration of dual cameras, Livox Mid-360, and Reach M+ see [Multi-Sensor Setup](doc/multi_sensor_setup.md).
+
 
 ## 1.Overview and Contributions (2024-10-23 Update)
 The system takes input from point cloud data collected by LiDAR, motion information collected by an Inertial Measurement Unit (IMU), and color and texture information captured by a camera. In the tracking thread, the ESIKF algorithm is used for tracking, achieving odometry output at the IMU frequency. In the mapping thread, the rendered color point cloud is used for Voxel-GPR, and then the data initialized 3D gaussian is input into the dense 3D gaussian map for rendering optimization. The final output is a high-quality dense 3D gaussian map. C, D, and S represent the rasterized color image, depth image, and silhouette image, respectively.

--- a/config/multi_sensor_example.yaml
+++ b/config/multi_sensor_example.yaml
@@ -1,0 +1,29 @@
+sensors:
+  camera_left:
+    topic: /camera_left/image_raw
+    frame_id: camera_left_frame
+    extrinsic:
+      translation: [0.1, 0.0, 0.05]
+      rotation: [0.0, 0.0, 0.0, 1.0]
+  camera_right:
+    topic: /camera_right/image_raw
+    frame_id: camera_right_frame
+    extrinsic:
+      translation: [-0.1, 0.0, 0.05]
+      rotation: [0.0, 0.0, 0.0, 1.0]
+  lidar:
+    topic: /livox/lidar
+    frame_id: livox_frame
+    extrinsic:
+      translation: [0.0, 0.0, 0.1]
+      rotation: [0.0, 0.0, 0.0, 1.0]
+  gnss:
+    topic: /reach/position
+    frame_id: gnss_frame
+    extrinsic:
+      translation: [0.0, 0.0, 0.0]
+      rotation: [0.0, 0.0, 0.0, 1.0]
+
+sync:
+  approx_sync: true
+  queue_size: 10

--- a/doc/multi_sensor_setup.md
+++ b/doc/multi_sensor_setup.md
@@ -1,0 +1,36 @@
+# Multi-Sensor Setup
+
+This guide describes wiring, calibration, and configuration for a platform equipped with dual cameras, a Livox Mid-360 LiDAR, and a Reach M+ GNSS module.
+
+## Wiring
+
+- **Cameras**: Connect both cameras to USB3 ports on the host computer. Use a hardware trigger to drive the shutters and share a common ground to keep the images synchronized.
+- **Livox Mid-360**: Power the sensor with a stable 12–24 V supply. Connect its Ethernet port directly to the PC or through a switch and configure the IP address within the same subnet.
+- **Reach M+**: Power the receiver and connect it to the PC via a serial‑to‑USB adapter for NMEA output. Optionally link the event pin to the camera trigger to record shutter times.
+- Use a shared power source or properly regulated supplies so all sensors reference the same ground.
+
+## Calibration
+
+1. **Camera intrinsics** – Calibrate each camera using a checkerboard with tools such as `camera_calibration` or `Kalibr`.
+2. **Extrinsics** – Estimate rigid transforms from `base_link` to each sensor (left camera, right camera, LiDAR, GNSS) using a calibration toolbox such as Kalibr or a LiDAR–camera calibration package.
+3. **GNSS antenna offset** – Measure the physical offset of the Reach M+ antenna relative to the LiDAR frame and include it in the extrinsic parameters.
+
+Record the resulting transformations in the [example configuration](../config/multi_sensor_example.yaml).
+
+## Configuration
+
+The repository provides example configuration and launch files:
+
+- [config/multi_sensor_example.yaml](../config/multi_sensor_example.yaml)
+- [launch/multi_sensor_example.launch](../launch/multi_sensor_example.launch)
+
+The YAML file lists topics, frames, and extrinsic parameters. The launch file loads the configuration, publishes static transforms, and starts a node that consumes synchronized camera, LiDAR, and GNSS topics.
+
+### Synchronized Topics
+
+The example node uses approximate time synchronization (`approx_sync: true`) with a configurable `queue_size`. Adjust these values to match your network latency and sensor rates.
+
+### Extrinsic Parameters
+
+Static transforms published in the launch file encode the extrinsic calibration between sensors. Replace the placeholder values in the configuration with the results from your calibration procedure.
+

--- a/launch/multi_sensor_example.launch
+++ b/launch/multi_sensor_example.launch
@@ -1,0 +1,24 @@
+<launch>
+  <!-- Example multi-sensor setup with dual cameras, Livox Mid-360, and Reach M+ -->
+  <rosparam command="load" file="$(find gslivm)/config/multi_sensor_example.yaml" />
+
+  <!-- Static transforms defining extrinsic calibration -->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="tf_left_camera"
+        args="0.1 0.0 0.05 0 0 0 1 base_link camera_left_frame" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="tf_right_camera"
+        args="-0.1 0.0 0.05 0 0 0 1 base_link camera_right_frame" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="tf_livox"
+        args="0 0 0.1 0 0 0 1 base_link livox_frame" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="tf_reach"
+        args="0 0 0 0 0 0 1 base_link gnss_frame" />
+
+  <!-- Example node consuming synchronized topics -->
+  <node pkg="gslivm" type="multi_sensor_node" name="multi_sensor_node" output="screen">
+    <param name="approx_sync" value="true" />
+    <param name="queue_size" value="10" />
+    <remap from="camera_left/image" to="/camera_left/image_raw" />
+    <remap from="camera_right/image" to="/camera_right/image_raw" />
+    <remap from="lidar/points" to="/livox/lidar" />
+    <remap from="gnss/fix" to="/reach/position" />
+  </node>
+</launch>


### PR DESCRIPTION
## Summary
- Document wiring, calibration, and configuration for dual cameras, Livox Mid-360, and Reach M+
- Provide example YAML and launch files with synchronized topics and extrinsic transforms
- Reference the new guide from the main README

## Testing
- `colcon test` *(command not found)*
- `catkin_make run_tests` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be46611fb48323b4c54e0ac9b5a34b