### PR TITLE
Add dataset runner script and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ mkdir /home/xieys/catkin_ws/output/training -p
 mv ${ROOT}/doc/sparse /home/xieys/catkin_ws/output
 ```
 
+You can also start the system with the helper script:
+
+```bash
+python scripts/run_dataset.py /path/to/sequence.bag r3live
+# with parameter overrides
+python scripts/run_dataset.py /path/to/sequence.bag ntu --override debug_output:=1
+```
+Supported sensor types: `r3live`, `ntu`, `fastlivo`, `botanic`, `botanic_livox`.
+
 
 
 ###  1). Run on [*R3Live_Dataset*](https://github.com/ziv-lin/r3live_dataset)

--- a/scripts/run_dataset.py
+++ b/scripts/run_dataset.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Utility script to launch GS-LIVM on recorded datasets.
+
+This script wraps ``roslaunch`` to run GS-LIVM with an input ROS bag.
+It selects the correct launch file based on the sensor type and forwards
+optional parameter overrides to ``roslaunch``.
+
+Example:
+    python scripts/run_dataset.py my.bag r3live \\
+        --override debug_output:=1 --override output_path:=/tmp/out
+"""
+import argparse
+import shlex
+import subprocess
+from typing import List
+
+# Mapping between human readable sensor types and roslaunch files
+SENSOR_LAUNCH_MAP = {
+    "r3live": "livo_r3live_compressed.launch",
+    "ntu": "livo_ntu.launch",
+    "fastlivo": "livo_fastlivo_compressed.launch",
+    "botanic": "livo_botanic_garden.launch",
+    "botanic_livox": "livo_botanic_garden_livox.launch",
+}
+
+
+def build_command(bag: str, sensor: str, overrides: List[str]) -> List[str]:
+    """Build the roslaunch command.
+
+    Args:
+        bag: Path to the rosbag file.
+        sensor: Sensor type key from ``SENSOR_LAUNCH_MAP``.
+        overrides: A list of parameter override strings ``name:=value``.
+
+    Returns:
+        A list representing the roslaunch command and its arguments.
+    """
+    launch_file = SENSOR_LAUNCH_MAP[sensor]
+    cmd = ["roslaunch", "gslivm", launch_file, f"bag_path:={bag}"]
+    for ov in overrides:
+        if ":=" not in ov:
+            # Allow KEY=VAL syntax for convenience
+            ov = ov.replace("=", ":=", 1)
+        cmd.append(ov)
+    return cmd
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run GS-LIVM on a dataset")
+    parser.add_argument("bag", help="Path to the ROS bag file")
+    parser.add_argument("sensor", choices=sorted(SENSOR_LAUNCH_MAP),
+                        help="Sensor/dataset type")
+    parser.add_argument(
+        "-o",
+        "--override",
+        action="append",
+        default=[],
+        help=(
+            "Parameter override in the form name:=value."
+            " Can be specified multiple times."
+        ),
+    )
+    args = parser.parse_args()
+
+    cmd = build_command(args.bag, args.sensor, args.override)
+    print("Running:", " ".join(shlex.quote(c) for c in cmd))
+    subprocess.run(cmd)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/run_dataset.py` to launch GS-LIVM with bag files and allow parameter overrides
- document helper script usage in README

## Testing
- `python scripts/run_dataset.py --help`
- `python -m py_compile scripts/run_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_68be46674dbc8323a3c6d5acc04e28d3