### PR TITLE
Add YAML config validator for node startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,8 +191,9 @@ add_executable(livo_node
 		src/liw/cloudProcessing.cpp 
 		src/liw/state.cpp
 		src/liw/eskfEstimator.cpp
-		src/liw/utility.cpp
-		src/liw/parameters.cpp
+                src/liw/utility.cpp
+                src/liw/parameters.cpp
+                src/liw/config_validator.cpp
     src/liw/cudaMatrixMultiply.cpp)
 
 target_link_libraries(livo_node ${catkin_LIBRARIES} ${PROJECT_NAME}.common ${PROJECT_NAME}.gs ${PROJECT_NAME}.gp3d ${CERES_LIBRARIES} ${OpenCV_LIBRARIES} tsl::robin_map)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ fi" >> ~/miniforge3/envs/{ENV_NAME}/setup.sh
 ```
 
 
+## Configuration Validation
+
+The node validates its YAML configuration at startup. Missing keys or type
+mismatches trigger a descriptive error and the node shuts down. Common mistakes
+include:
+
+* Omitting `common/lidar_topic` → `Missing required parameter 'common/lidar_topic'`
+* Setting `extrinsic_parameter/extrinsic_enable` to a non-boolean value →
+  `Parameter 'extrinsic_parameter/extrinsic_enable' has wrong type (expected boolean)`
+* Providing a `common/gravity_acc` list with a length other than three →
+  `Parameter 'common/gravity_acc' must contain exactly three elements`
+
+Correct the YAML file and relaunch if any of these messages appear.
+
 ## 4.Run on Public Datasets
 
 ```Bash

--- a/include/liw/config_validator.h
+++ b/include/liw/config_validator.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <ros/ros.h>
+
+// Validate required parameters loaded from YAML files.
+// Throws std::runtime_error on the first problem encountered.
+void validateParameters(ros::NodeHandle& nh);

--- a/src/liw/config_validator.cpp
+++ b/src/liw/config_validator.cpp
@@ -1,0 +1,65 @@
+#include "liw/config_validator.h"
+
+#include <XmlRpcValue.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+struct ParamSpec {
+  std::string name;
+  XmlRpc::XmlRpcValue::Type type;
+};
+
+std::string typeToString(XmlRpc::XmlRpcValue::Type type) {
+  switch (type) {
+    case XmlRpc::XmlRpcValue::TypeString:
+      return "string";
+    case XmlRpc::XmlRpcValue::TypeInt:
+      return "integer";
+    case XmlRpc::XmlRpcValue::TypeDouble:
+      return "double";
+    case XmlRpc::XmlRpcValue::TypeBoolean:
+      return "boolean";
+    case XmlRpc::XmlRpcValue::TypeArray:
+      return "list";
+    default:
+      return "unknown";
+  }
+}
+}  // namespace
+
+void validateParameters(ros::NodeHandle& nh) {
+  std::vector<ParamSpec> required{
+      {"common/lidar_topic", XmlRpc::XmlRpcValue::TypeString},
+      {"common/imu_topic", XmlRpc::XmlRpcValue::TypeString},
+      {"common/image_topic", XmlRpc::XmlRpcValue::TypeString},
+      {"common/image_type", XmlRpc::XmlRpcValue::TypeString},
+      {"common/gravity_acc", XmlRpc::XmlRpcValue::TypeArray},
+      {"lidar_parameter/lidar_type", XmlRpc::XmlRpcValue::TypeInt},
+      {"imu_parameter/acc_cov", XmlRpc::XmlRpcValue::TypeDouble},
+      {"camera_parameter/image_width", XmlRpc::XmlRpcValue::TypeInt},
+      {"camera_parameter/image_height", XmlRpc::XmlRpcValue::TypeInt},
+      {"extrinsic_parameter/extrinsic_enable", XmlRpc::XmlRpcValue::TypeBoolean},
+  };
+
+  for (const auto& spec : required) {
+    XmlRpc::XmlRpcValue val;
+    if (!nh.getParam(spec.name, val)) {
+      throw std::runtime_error("Missing required parameter '" + spec.name + "'");
+    }
+    if (spec.type == XmlRpc::XmlRpcValue::TypeDouble) {
+      if (val.getType() != XmlRpc::XmlRpcValue::TypeDouble && val.getType() != XmlRpc::XmlRpcValue::TypeInt) {
+        throw std::runtime_error("Parameter '" + spec.name + "' has wrong type (expected number)");
+      }
+    } else if (val.getType() != spec.type) {
+      throw std::runtime_error(
+          "Parameter '" + spec.name + "' has wrong type (expected " + typeToString(spec.type) + ")");
+    }
+    if (spec.name == "common/gravity_acc") {
+      if (val.size() != 3) {
+        throw std::runtime_error("Parameter 'common/gravity_acc' must contain exactly three elements");
+      }
+    }
+  }
+}

--- a/src/liw/lioOptimization.cpp
+++ b/src/liw/lioOptimization.cpp
@@ -1,4 +1,5 @@
 #include "liw/lioOptimization.h"
+#include "liw/config_validator.h"
 
 #include <cnpy.h>
 #include <algorithm>
@@ -203,6 +204,7 @@ estimationSummary::estimationSummary() {}
 void estimationSummary::release() {}
 
 lioOptimization::lioOptimization() {
+  validateParameters(nh);
   allocateMemory();
 
   readParameters();
@@ -2482,7 +2484,12 @@ int main(int argc, char** argv) {
   ros::init(argc, argv, "livo_node");
 
   std::shared_ptr<lioOptimization> lio;
-  lio.reset(new lioOptimization());
+  try {
+    lio.reset(new lioOptimization());
+  } catch (const std::exception& e) {
+    ROS_ERROR("%s", e.what());
+    return 1;
+  }
 
 #ifdef _OPENMP
   int NUM_THREADS = omp_get_num_procs() / 4;


### PR DESCRIPTION
## Summary
- add C++ validator to check required YAML parameters and types
- call validator during `livo_node` startup with clear error messages
- document common configuration mistakes and resulting validator output

## Testing
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be466df448832390328c74bd34b2ee