### PR TITLE
Fix logical operator in image mismatch logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ mamba install --file conda_pkgs.txt -c nvidia -c pytorch -c conda-forge
 ```
 
 ## 3. Build GS-LIVM and Source
+Ensure ROS catkin tools (e.g., `catkin` or `colcon`) are installed. If CUDA is unavailable, configure with `-DBUILD_GS=OFF` during CMake.
 Clone the repository and catkin_make:
 ``` Bash
 # build

--- a/src/liw/lioOptimization.cpp
+++ b/src/liw/lioOptimization.cpp
@@ -804,7 +804,7 @@ void lioOptimization::imageHandler(const sensor_msgs::ImageConstPtr& msg) {
   cv::Mat image = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8)->image.clone();
 
   if (image.cols != image_width_verify || image.rows != image_height_verify) {
-    std::cout << image.cols << " != " << image_width_verify << " && " << image.rows << " != " << image_height_verify
+    std::cout << image.cols << " != " << image_width_verify << " || " << image.rows << " != " << image_height_verify
               << std::endl;
     exit(-1);
   }
@@ -841,7 +841,7 @@ void lioOptimization::compressedImageHandler(const sensor_msgs::CompressedImageC
   }
 
   if (image.cols != image_width_verify || image.rows != image_height_verify) {
-    std::cout << image.cols << " != " << image_width_verify << " && " << image.rows << " != " << image_height_verify
+    std::cout << image.cols << " != " << image_width_verify << " || " << image.rows << " != " << image_height_verify
               << std::endl;
     exit(-1);
   }


### PR DESCRIPTION
## Summary
- Align image size mismatch logging with logical OR checks in both raw and compressed image handlers
- Document required build tools and how to disable CUDA during configuration

## Testing
- `colcon build --event-handlers console_direct+ --packages-select gslivm` *(command not found: colcon)*
- `catkin_make` *(command not found: catkin_make)*
- `cmake -S . -B build -DBUILD_GS=OFF` *(fails: Could not find catkin)*
- `apt-get update` *(fails: repository not signed; 403 Forbidden)*
- `g++ -x c++ - <<'EOF'...; ./a.out`

------
https://chatgpt.com/codex/tasks/task_e_68be5dd4ea648323a9b688f2a74ca2bc