### PR TITLE
Add ROS-enabled CUDA Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,36 @@
-# Use micromamba for efficient conda environment management
-FROM mambaorg/micromamba:1.5.7
+FROM nvidia/cuda:11.7.1-devel-ubuntu20.04
 
-# Set working directory
-WORKDIR /workspace/GS-LIVM
+# Avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Copy environment file and create the conda environment
-COPY env.yaml /tmp/env.yaml
-RUN micromamba env create -f /tmp/env.yaml && \
-    micromamba clean --all --yes
+# Install ROS Noetic and development tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl gnupg2 lsb-release build-essential cmake git python3-catkin-tools \
+        python3-rosdep python3-rosinstall python3-rosinstall-generator python3-wstool \
+    && curl -sSL "https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc" | apt-key add - \
+    && echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ros-noetic-desktop-full \
+    && rosdep init \
+    && rosdep update \
+    && rm -rf /var/lib/apt/lists/*
 
-# Make the environment active by default
-ENV PATH="/opt/conda/envs/gslivm/bin:$PATH"
+ENV ROS_DISTRO=noetic
 
-# Copy project files
-COPY . /workspace/GS-LIVM
+SHELL ["/bin/bash", "-c"]
 
-# Default command
-CMD ["bash"]
+# Source ROS environment by default
+RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /root/.bashrc
+
+# Verify CUDA availability
+RUN nvcc --version
+
+# Set up catkin workspace and build repository
+WORKDIR /root/catkin_ws
+RUN mkdir -p src
+COPY . /root/catkin_ws/src/GS-LIVM
+RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
+    catkin init && \
+    catkin build
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary
- Replace Dockerfile with NVIDIA CUDA 11.7 / Ubuntu 20.04 image
- Install ROS Noetic desktop-full, development tools, and catkin
- Configure catkin workspace to build repository during image build

## Testing
- ⚠️ `python -m pytest` (fails: ModuleNotFoundError: No module named 'rospy')

------
https://chatgpt.com/codex/tasks/task_e_68be6e0eefb48323b6eac84158cb6287