### PR TITLE
Clean up CMake conflict and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,39 +204,9 @@ target_link_libraries(livo_node ${catkin_LIBRARIES} ${PROJECT_NAME}.common ${PRO
 
 add_executable(gnss_adapter src/liw/gnssAdapter.cpp)
 target_link_libraries(gnss_adapter ${catkin_LIBRARIES} ${GeographicLib_LIBRARIES})
-
-# gmm
-# find_package(Open3D REQUIRED)  
-# include_directories(${Open3D_INCLUDE_DIR} src/test/gmm)
-
-# add_library(${PROJECT_NAME}.gmm src/test/gmm/GMMFit.cpp)
-# target_link_libraries(${PROJECT_NAME}.gmm ${gs_libs} Open3D::Open3D)
-
-# add_executable(
-#   ${PROJECT_NAME}_test_gmm
-#   src/test/test_gmm.cpp
-# )
-# target_link_libraries(${PROJECT_NAME}_test_gmm  ${PROJECT_NAME}.gmm )
-
-# eclipse
-# find_package(Open3D REQUIRED)  
-# include_directories(${Open3D_INCLUDE_DIR})
-
-# add_executable(
-#   ${PROJECT_NAME}_test_ecli
-#   src/test/test_ecli.cpp
-# )
-# target_link_libraries(${PROJECT_NAME}_test_ecli ${gs_libs} Open3D::Open3D )
-
-# hash
-# add_executable(
-#   ${PROJECT_NAME}_test_hash
-#   src/test/test_hash.cpp
-# )
-
-# target_link_libraries(${PROJECT_NAME}_test_hash  pthread)
-
+ 
 if(CATKIN_ENABLE_TESTING)
+  add_subdirectory(test)
   find_package(rostest REQUIRED)
   rostest_add_rostest(test/slam.test)
 endif()


### PR DESCRIPTION
## Summary
- remove old commented-out test code
- ensure gnss adapter is linked and test suite added via catkin

## Testing
- `cmake -S . -B build -DBUILD_GS=OFF` *(fails: Could not find a package configuration file provided by "catkin")*

------
https://chatgpt.com/codex/tasks/task_e_68be6e6ef79483239c051b28e4f00506