### PR TITLE
Add world-to-view transform utilities and tests

### DIFF
--- a/include/gs/gs/camera.cuh
+++ b/include/gs/gs/camera.cuh
@@ -11,6 +11,7 @@
 #include "gs/parameters.cuh"
 #include "gs/stb_image.h"
 #include "gs/stb_image_resize.h"
+#include "camera_utils.cuh"
 
 // enum class CAMERA_MODEL {
 //   SIMPLE_PINHOLE = 0,
@@ -121,18 +122,17 @@ namespace gs::param {
 struct ModelParameters;
 }
 
-// torch::Tensor getWorld2View2(
-//     const Eigen::Matrix3f& R,
-//     const Eigen::Vector3f& t,
-//     const Eigen::Vector3f& translate = Eigen::Vector3f::Zero(),
-//     float scale = 1.0);
+torch::Tensor getWorld2View2(
+    const Eigen::Matrix3f& R,
+    const Eigen::Vector3f& t,
+    const Eigen::Vector3f& translate = Eigen::Vector3f::Zero(),
+    float scale = 1.0f);
 
-// TODO: hacky. Find better way
-// Eigen::Matrix4f getWorld2View2Eigen(
-//     const Eigen::Matrix3f& R,
-//     const Eigen::Vector3f& t,
-//     const Eigen::Vector3f& translate = Eigen::Vector3f::Zero(),
-//     float scale = 1.0);
+Eigen::Matrix4f getWorld2View2Eigen(
+    const Eigen::Matrix3f& R,
+    const Eigen::Vector3f& t,
+    const Eigen::Vector3f& translate = Eigen::Vector3f::Zero(),
+    float scale = 1.0f);
 
 torch::Tensor getProjectionMatrix(float znear, float zfar, float fovX, float fovY);
 

--- a/include/gs/gs/camera_utils.cuh
+++ b/include/gs/gs/camera_utils.cuh
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+inline Eigen::Matrix4f getWorld2View2Eigen(
+    const Eigen::Matrix3f& R,
+    const Eigen::Vector3f& t,
+    const Eigen::Vector3f& translate = Eigen::Vector3f::Zero(),
+    float scale = 1.0f) {
+  Eigen::Matrix4f Rt = Eigen::Matrix4f::Identity();
+  Rt.block<3, 3>(0, 0) = R.transpose();
+  Rt.block<3, 1>(0, 3) = -R.transpose() * t;
+
+  Eigen::Matrix4f C2W = Rt.inverse();
+  Eigen::Vector3f cam_center = C2W.block<3, 1>(0, 3);
+  cam_center = (cam_center + translate) * scale;
+  C2W.block<3, 1>(0, 3) = cam_center;
+  return C2W.inverse();
+}
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,3 +23,7 @@ target_link_libraries(test_eskf_estimator eskf gtest_main)
 
 enable_testing()
 add_test(NAME eskf_estimator_test COMMAND test_eskf_estimator)
+
+add_executable(test_camera_utils test_camera_utils.cpp)
+target_link_libraries(test_camera_utils gtest_main Eigen3::Eigen)
+add_test(NAME camera_utils_test COMMAND test_camera_utils)

--- a/test/test_camera_utils.cpp
+++ b/test/test_camera_utils.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+
+#include "gs/gs/camera_utils.cuh"
+
+TEST(CameraUtilsTest, IdentityTransform) {
+  Eigen::Matrix3f R = Eigen::Matrix3f::Identity();
+  Eigen::Vector3f t = Eigen::Vector3f::Zero();
+  Eigen::Matrix4f expected = Eigen::Matrix4f::Identity();
+  Eigen::Matrix4f result = getWorld2View2Eigen(R, t);
+  EXPECT_TRUE(expected.isApprox(result, 1e-5f));
+}
+
+TEST(CameraUtilsTest, TranslationAndScale) {
+  Eigen::Matrix3f R = Eigen::Matrix3f::Identity();
+  Eigen::Vector3f t = Eigen::Vector3f::Zero();
+  Eigen::Vector3f translate(1.f, 0.f, 0.f);
+  float scale = 2.f;
+  Eigen::Matrix4f result = getWorld2View2Eigen(R, t, translate, scale);
+  Eigen::Matrix4f expected = Eigen::Matrix4f::Identity();
+  expected(0, 3) = -2.f;
+  EXPECT_TRUE(expected.isApprox(result, 1e-5f));
+}
+


### PR DESCRIPTION
## Summary
- add `getWorld2View2Eigen` utility for building world-to-view matrices
- expose torch wrapper `getWorld2View2`
- add unit tests for camera utilities

## Testing
- `cd test && rm -rf build && mkdir build && cd build && cmake .. && make test_camera_utils && ctest --output-on-failure` *(fails: HTTP 403 when downloading googletest)*

------
https://chatgpt.com/codex/tasks/task_e_68be719205448323b0f69437315ec8a8