### PR TITLE
chore: remove redundant packages from env

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -46,7 +46,6 @@ dependencies:
   - c-compiler=1.5.0=h166bdaf_0
   - ca-certificates=2025.4.26=hbd8a1cb_0
   - cached-property=1.5.2=hd8ed1ab_1
-  - cached_property=1.5.2=pyha770c72_1
   - cachetools=5.3.3=pyhd8ed1ab_0
   - cairo=1.16.0=ha12eb4b_1010
   - catkin_pkg=1.0.0=pyhd8ed1ab_0
@@ -194,7 +193,6 @@ dependencies:
   - imath=3.1.6=h6239696_1
   - importlib-resources=6.4.0=pyhd8ed1ab_0
   - importlib_metadata=8.2.0=hd8ed1ab_0
-  - importlib_resources=6.4.0=pyhd8ed1ab_0
   - intel-openmp=2023.1.0=hdb19cb5_46306
   - ipykernel=6.29.5=pyh3099207_0
   - ipython=8.18.1=pyh707e725_3
@@ -456,7 +454,6 @@ dependencies:
   - proj=9.0.0=h93bde94_1
   - prometheus_client=0.20.0=pyhd8ed1ab_0
   - prompt-toolkit=3.0.47=pyha770c72_0
-  - prompt_toolkit=3.0.47=hd8ed1ab_0
   - psutil=5.9.8=py39hd1e30aa_0
   - pthread-stubs=0.4=h36c2ea0_1001
   - ptyprocess=0.7.0=pyhd3deb0d_0
@@ -469,8 +466,7 @@ dependencies:
   - pybind11-global=2.12.0=py39h7633fee_0
   - pycairo=1.25.0=py39hc92de75_1
   - pycparser=2.22=pyhd8ed1ab_0
-  - pycryptodome=3.20.0=py39h6f9bf71_0
-  - pycryptodomex=3.19.0=py39hd1e30aa_1
+  - pycryptodome=3.20.0=py39h6f9bf71_0  # pycryptodomex removed as duplicate
   - pydot=2.0.0=py39hf3d152e_0
   - pygments=2.18.0=pyhd8ed1ab_0
   - pynacl=1.5.0=py39hd1e30aa_3
@@ -744,7 +740,6 @@ dependencies:
   - rosdep=0.24.0=pyhd8ed1ab_0
   - rosdistro=0.9.0=py39hf3d152e_1
   - rospkg=1.5.1=pyhd8ed1ab_0
-  - ruamel_yaml=0.15.80=py39hd1e30aa_1009
   - ruby=3.1.2=h22ca3a2_0
   - sbcl=2.2.11=ha66036c_5
   - scikit-image=0.24.0=py39hfc16268_1
@@ -786,7 +781,6 @@ dependencies:
   - types-pkg_resources=0.1.3=pyhd8ed1ab_0
   - types-python-dateutil=2.9.0.20240316=pyhd8ed1ab_0
   - typing-extensions=4.12.2=hd8ed1ab_0
-  - typing_extensions=4.12.2=pyha770c72_0
   - typing_utils=0.1.0=pyhd8ed1ab_0
   - tzcode=2024a=h3f72095_0
   - unicodedata2=15.1.0=py39hd1e30aa_0
@@ -863,7 +857,6 @@ dependencies:
       - evo==1.29.0
       - fire==0.7.0
       - flask==3.0.3
-      - importlib-metadata==8.0.0
       - itsdangerous==2.2.0
       - jsonschema==4.22.0
       - lark==1.2.2
@@ -878,8 +871,8 @@ dependencies:
       - retrying==1.3.4
       - rosbags==0.9.23
       - rpds-py==0.18.1
-      - ruamel-yaml==0.18.6
-      - ruamel-yaml-clib==0.2.8
+      - ruamel-yaml==0.18.6        # paired with ruamel-yaml-clib below
+      - ruamel-yaml-clib==0.2.8    # C extensions for ruamel-yaml
       - spconv-cu120==2.3.6
       - tenacity==8.4.2
       - tzdata==2024.1


### PR DESCRIPTION
## Summary
- remove overlapping packages such as pycryptodomex, cached_property, prompt_toolkit, typing_extensions, importlib_resources, and duplicate ruamel_yaml
- document retention of pycryptodome and ruamel-yaml pair

## Testing
- `conda env create --dry-run -f env.yaml` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rospy')*

------
https://chatgpt.com/codex/tasks/task_e_68be71aa83b483239d9714a1d3a9178f