### PR TITLE
chore: remove duplicate jsonschema dependency

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -209,7 +209,7 @@ dependencies:
   - jsoncpp=1.9.5=h4bd325d_1
   - jsonpointer=3.0.0=py39hf3d152e_0
   - jsonschema-specifications=2023.12.1=pyhd8ed1ab_0
-  - jsonschema-with-format-nongpl=4.23.0=hd8ed1ab_0
+  - jsonschema-with-format-nongpl=4.23.0=hd8ed1ab_0  # provides jsonschema; removed duplicate pip installation
   - jupyter=1.0.0=pyhd8ed1ab_10
   - jupyter-lsp=2.2.5=pyhd8ed1ab_0
   - jupyter_client=8.6.2=pyhd8ed1ab_0
@@ -488,7 +488,7 @@ dependencies:
   - pytorch=2.0.1=gpu_cuda118py39he342708_0
   - pytz=2024.1=pyhd8ed1ab_0
   - pywavelets=1.6.0=py39hd92a3bb_0
-  - pyyaml=6.0.1=py39hd1e30aa_1
+  - pyyaml=6.0.1=py39hd1e30aa_1  # required for ROS; ruamel-yaml used elsewhere
   - pyzmq=26.0.3=py39ha1047a2_0
   - qhull=2020.2=h4bd325d_2
   - qt=5.12.9=h1304e3e_6
@@ -858,7 +858,6 @@ dependencies:
       - fire==0.7.0
       - flask==3.0.3
       - itsdangerous==2.2.0
-      - jsonschema==4.22.0
       - lark==1.2.2
       - natsort==8.4.0
       - ninja==1.11.1.4


### PR DESCRIPTION
## Summary
- drop pip-installed jsonschema, rely on conda package
- document intentional use of pyyaml alongside ruamel-yaml

## Testing
- `conda env create -f env.yaml --dry-run` *(fails: command not found)*
- `wget https://micromamba.snakepit.net/api/micromamba/linux-64/latest -O micromamba.tar.bz2` *(fails: Proxy tunneling failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be769893d08323b7901c8d5405604d