### PR TITLE
Remove unused getWorld2View2Eigen prototype and add torch tests

### DIFF
--- a/include/gs/gs/camera.cuh
+++ b/include/gs/gs/camera.cuh
@@ -128,12 +128,6 @@ torch::Tensor getWorld2View2(
     const Eigen::Vector3f& translate = Eigen::Vector3f::Zero(),
     float scale = 1.0f);
 
-Eigen::Matrix4f getWorld2View2Eigen(
-    const Eigen::Matrix3f& R,
-    const Eigen::Vector3f& t,
-    const Eigen::Vector3f& translate = Eigen::Vector3f::Zero(),
-    float scale = 1.0f);
-
 torch::Tensor getProjectionMatrix(float znear, float zfar, float fovX, float fovY);
 
 float fov2focal(float fov, int pixels);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,11 @@ FetchContent_MakeAvailable(googletest)
 
 find_package(Eigen3 REQUIRED)
 
-include_directories(${EIGEN3_INCLUDE_DIR} ../include)
+include("../cmake/torch.cmake")
+list(APPEND CMAKE_PREFIX_PATH ${TORCH_CMAKE_PREFIX_PATH} $ENV{CMAKE_PREFIX_PATH})
+find_package(Torch REQUIRED)
+
+include_directories(${EIGEN3_INCLUDE_DIR} ${TORCH_INCLUDE_DIRS} ../include)
 
 add_library(eskf STATIC ../src/liw/eskfEstimator.cpp)
 target_include_directories(eskf PRIVATE ../include)
@@ -25,5 +29,5 @@ enable_testing()
 add_test(NAME eskf_estimator_test COMMAND test_eskf_estimator)
 
 add_executable(test_camera_utils test_camera_utils.cpp)
-target_link_libraries(test_camera_utils gtest_main Eigen3::Eigen)
+target_link_libraries(test_camera_utils gtest_main Eigen3::Eigen ${TORCH_LIBRARIES})
 add_test(NAME camera_utils_test COMMAND test_camera_utils)

--- a/test/test_camera_utils.cpp
+++ b/test/test_camera_utils.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 #include <Eigen/Dense>
+#include <torch/torch.h>
+#include <cstring>
 
+#include "gs/gs/camera.cuh"
 #include "gs/gs/camera_utils.cuh"
 
 TEST(CameraUtilsTest, IdentityTransform) {
@@ -17,6 +20,29 @@ TEST(CameraUtilsTest, TranslationAndScale) {
   Eigen::Vector3f translate(1.f, 0.f, 0.f);
   float scale = 2.f;
   Eigen::Matrix4f result = getWorld2View2Eigen(R, t, translate, scale);
+  Eigen::Matrix4f expected = Eigen::Matrix4f::Identity();
+  expected(0, 3) = -2.f;
+  EXPECT_TRUE(expected.isApprox(result, 1e-5f));
+}
+
+TEST(CameraUtilsTest, TorchIdentityTransform) {
+  Eigen::Matrix3f R = Eigen::Matrix3f::Identity();
+  Eigen::Vector3f t = Eigen::Vector3f::Zero();
+  Eigen::Matrix4f expected = Eigen::Matrix4f::Identity();
+  torch::Tensor tensor = getWorld2View2(R, t);
+  Eigen::Matrix4f result;
+  std::memcpy(result.data(), tensor.data_ptr<float>(), sizeof(float) * 16);
+  EXPECT_TRUE(expected.isApprox(result, 1e-5f));
+}
+
+TEST(CameraUtilsTest, TorchTranslationAndScale) {
+  Eigen::Matrix3f R = Eigen::Matrix3f::Identity();
+  Eigen::Vector3f t = Eigen::Vector3f::Zero();
+  Eigen::Vector3f translate(1.f, 0.f, 0.f);
+  float scale = 2.f;
+  torch::Tensor tensor = getWorld2View2(R, t, translate, scale);
+  Eigen::Matrix4f result;
+  std::memcpy(result.data(), tensor.data_ptr<float>(), sizeof(float) * 16);
   Eigen::Matrix4f expected = Eigen::Matrix4f::Identity();
   expected(0, 3) = -2.f;
   EXPECT_TRUE(expected.isApprox(result, 1e-5f));


### PR DESCRIPTION
## Summary
- drop redundant getWorld2View2Eigen forward declaration from camera.cuh
- add torch-based unit tests for world-to-view transform
- link tests against Torch

## Testing
- `cmake ..` *(fails: Each download failed... HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be769b947883239667bcb82d261aed