### PR TITLE
chore: merge experimental script ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,15 @@ doc/video.mp4
 # generated mapping data produced by the mapping pipeline
 output/
 
-# python scratch scripts (kept out of version control)
+# experimental scripts used during development
 python/calc_det.py          # matrix determinant demo
 python/calc_extrinsic.py    # quick extrinsic calculator
 python/see_depth_l1.py      # depth comparison utility
 python/see_image.py         # image viewer for debugging
+python/cat_image.py
+python/evaluate_no_split.py
+python/extract_image.py
+python/parse_pose.py
+python/parse_to_nerfslam.py
+python/plot_figure.py
+python/verbose_traj.py


### PR DESCRIPTION
## Summary
- merge conflicting experimental script lists
- retain descriptive comments for calc_det, calc_extrinsic, see_depth_l1, and see_image

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rospy')*

------
https://chatgpt.com/codex/tasks/task_e_68be7af869e8832395a5de5c099a2f96